### PR TITLE
Lean default ranking towards fastest over fairness

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -103,7 +103,7 @@ export default function Home() {
     setError(null);
 
     try {
-      const fairnessWeight = 0.55; // Fixed at balanced (middle) position
+      const fairnessWeight = 0.325; // Leaning towards fastest (one in from left on the old slider)
       const response = await fetch("/api/fairest", {
         method: "POST",
         headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
Shift the hardcoded fairnessWeight from 0.55 (Balanced) to 0.325 (Leaning Towards Fastest), matching what position 1 of the old slider produced. Users tend to care more about journey time than perfect fairness between travellers.

https://claude.ai/code/session_01FbJQLbUasYeBZpUYU2VNNm